### PR TITLE
Fix comment order mutation

### DIFF
--- a/src/Components/CommentBlock.tsx
+++ b/src/Components/CommentBlock.tsx
@@ -390,7 +390,7 @@ function CommentBlock({
 
       {replies.length > 0 && (
         <Collapse in={expanded} timeout="auto" unmountOnExit>
-          {replies.reverse().map((reply) => (
+          {replies.slice().reverse().map((reply) => (
             <CommentBlock
               handleCommentCreate={handleCommentCreate}
               setGeneratingCommentsChain={setGeneratingCommentsChain}

--- a/src/Pages/Post.tsx
+++ b/src/Pages/Post.tsx
@@ -361,6 +361,7 @@ function PostPage({
                 {commentsChain &&
                   commentsChain.length > 0 &&
                   commentsChain
+                    .slice()
                     .reverse()
                     .map((comment, index) => (
                       <CommentBlock


### PR DESCRIPTION
## Summary
- avoid mutating `replies` array in `CommentBlock`
- avoid mutating `commentsChain` in `Post`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*